### PR TITLE
Remove version from minified filename

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
           banner: '/*! <%= pkg.name %>.min.js v<%= pkg.version %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
         },
         files: {
-          './<%= pkg.name %>-<%= pkg.version %>.min.js': 'src/<%= pkg.name %>.js'
+          './<%= pkg.name %>.min.js': 'src/<%= pkg.name %>.js'
         }
       }
     },


### PR DESCRIPTION
Including the version in the minified file might make sense from a dev standpoint, but for us poor `grunt-bower-install`-less users its a pain. :)
