### PR TITLE
Check for element before init

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -823,10 +823,14 @@
   }
 
   $.fn.clndr = function(options) {
-    if( !$.data( this, 'plugin_clndr') ) {
-      var clndr_instance = new Clndr(this, options);
-      $.data(this, 'plugin_clndr', clndr_instance);
-      return clndr_instance;
+    if(this.length === 1) {
+      if(!$.data( this, 'plugin_clndr')) {
+        var clndr_instance = new Clndr(this, options);
+        $.data(this, 'plugin_clndr', clndr_instance);
+        return clndr_instance;
+      }
+    } else if(this.length > 1) {
+      throw new Error("CLNDR does not support multiple elements yet.");
     }
   }
 


### PR DESCRIPTION
CLND should check the element(s) returned by the selector. If the element doesn't exist, it can cause errors later on (in my case, I used data attributes to pass options to calendar, which returned null...)

If the selector returns multiple elements, that's an error. Implementing multiple element selector handling would be a BC break because of the return statement. `return clndr_instance;`
