### PR TITLE
add class with day of the week index

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -377,6 +377,9 @@
     // uniqueness of IDs.
     extraClasses += " calendar-day-" + day.format("YYYY-MM-DD");
 
+    // day of week
+    extraClasses += " calendar-dow-" + day.weekday();
+
     return this.calendarDay({
       day: day.date(),
       classes: this.options.targets.day + extraClasses,


### PR DESCRIPTION
Just wondering if you'd consider added a class like `day-0` thru `day-6` (or `dow` or similar) to the [`extraClasses`](https://github.com/kylestetz/CLNDR/blob/master/src/clndr.js#L378) string?

I realize this is trivial to add in a template via the Moment.js date object—just thought it might save a step for people down the road.

For the record, my use case was to style weekends differently than weekdays...
