### PR TITLE
Support npm as a client-side package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Development environment for clndr.js",
   "author": "Kyle Stetz",
   "license": "MIT",
+  "main": "src/clndr.js",
+  "dependencies": {
+    "jquery": ">=1.9",
+    "moment": ">=2.2.1"
+  },
   "devDependencies": {
     "grunt": "*",
     "grunt-contrib-uglify": "~0.2.4",


### PR DESCRIPTION
Thanks to your use of UMD, this is the only change necessary to use clndr with f.ex. browserify and npm.

This, and `npm publish`.
