### PR TITLE
Day creation using UTC timezone to prevent DST from screwing the calenda...

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -1,4 +1,3 @@
-/*! clndr.min.js v1.2.2 2014-10-15 */
 /*
  *               ~ CLNDR v1.2.3 ~
  * ==============================================
@@ -306,7 +305,7 @@
 
     if(this.options.showAdjacentMonths) {
       for(var i = 0; i < diff; i++) {
-        var day = moment.utc([currentMonth.year(), currentMonth.month(), i - diff + 1]);
+        var day = moment([currentMonth.year(), currentMonth.month(), i - diff + 1]);
         daysArray.push( this.createDayObject(day, this.eventsLastMonth) );
       }
     } else {
@@ -341,7 +340,7 @@
       var start = moment(daysArray[daysArray.length - 1].date).add(1, 'days');
       while(daysArray.length < 42) {
         if(this.options.showAdjacentMonths) {
-          daysArray.push( this.createDayObject(moment.utc(start), this.eventsNextMonth) );
+          daysArray.push( this.createDayObject(moment(start), this.eventsNextMonth) );
           start.add(1, 'days');
         } else {
           daysArray.push( this.calendarDay({ classes: this.options.targets.empty + " next-month" }) );


### PR DESCRIPTION
Made some small changes to clndr.js to prevent some problems occurring in time zones with DST (Daylight Saving Time). This time zones made a specific day of the year get calculated one hour before (23:00 instead of 00:00) thus making the calendar show a duplicated day.

The changes make CLNDR get the time from the UTC instead of the local time zone. This changes have been made to clndr.js and NOT clndr.min.js. clndr.js must be minified before publishing to master.

Thanks for this awesome plug-in!

Regards,

Daniel Merrill.
