### PR TITLE
Support custom event types

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -404,7 +404,6 @@
       extraClasses += (" " + this.options.classes.event);
       //To support custom classes for events
       eventsToday.forEach(function(e) {
-        console.log(e);
         if(e.type) {
           extraClasses += (" " + self.options.classes.event + "-" + e.type);
         }

--- a/src/clndr.js
+++ b/src/clndr.js
@@ -402,6 +402,13 @@
     }
     if(eventsToday.length) {
       extraClasses += (" " + this.options.classes.event);
+      //To support custom classes for events
+      eventsToday.forEach(function(e) {
+        console.log(e);
+        if(e.type) {
+          extraClasses += (" " + self.options.classes.event + "-" + e.type);
+        }
+      });
     }
     if(this.month.month() > day.month()) {
       extraClasses += (" " + this.options.classes.adjacentMonth);


### PR DESCRIPTION
If an event has the property "type" add another class "event-{type}" to support different kind of events and be able to display them differently.

Not sure if that is any helpful for anybody else, if not just discard this PR :)