### PR TITLE
Performance improvement for multiday enabled calendars with single day events

### DIFF
--- a/example/test.html
+++ b/example/test.html
@@ -30,6 +30,9 @@
     <p>clndr.multidayMixed ~ Show multi-day events (12th - 17th, 24th - 27th), plus a single day event (19th). Logs in the console.</p>
     <div id="multiday-mixed" class="cal1"></div>
 
+    <p>clndr.multidayMixedPerformance ~ Show multi-day events (12th - 17th, 24th - 27th), plus 168 single day events over 3 months. Rendered in <span id="multiday-mixed-performance-val"></span> seconds. Logs in the console.</p>
+    <div id="multiday-mixed-performance" class="cal1"></div>
+
     <p>clndr.multidayLong ~ Show multi-day events (12th - 17th, 24th - 27th). Logs in the console.</p>
     <div id="multiday-long" class="cal1"></div>
 

--- a/example/test.html
+++ b/example/test.html
@@ -30,7 +30,7 @@
     <p>clndr.multidayMixed ~ Show multi-day events (12th - 17th, 24th - 27th), plus a single day event (19th). Logs in the console.</p>
     <div id="multiday-mixed" class="cal1"></div>
 
-    <p>clndr.multidayMixedPerformance ~ Show multi-day events (12th - 17th, 24th - 27th), plus 168 single day events over 3 months. Rendered in <span id="multiday-mixed-performance-val"></span> seconds. Logs in the console.</p>
+    <p>clndr.multidayMixedPerformance ~ Show multi-day events (12th - 17th, 24th - 27th), plus 280 single day events. Rendered in <span id="multiday-mixed-performance-val"></span> seconds. Logs in the console.</p>
     <div id="multiday-mixed-performance" class="cal1"></div>
 
     <p>clndr.multidayLong ~ Show multi-day events (12th - 17th, 24th - 27th). Logs in the console.</p>

--- a/example/test.js
+++ b/example/test.js
@@ -116,15 +116,9 @@ $( function() {
 
   // Add two events a day for three months
   for (var i = 1; i < 28; i++) {
-    // Last month
-    multidayMixedPerfArray.push({ startDate: moment().add(-1, 'month').format('YYYY-MM-') + i, endDate: moment().add(-1, 'month').format('YYYY-MM-') + i, title: 'Single'+ ((2 * i) - 1) });
-    multidayMixedPerfArray.push({ startDate: moment().add(-1, 'month').format('YYYY-MM-') + i, endDate: moment().add(-1, 'month').format('YYYY-MM-') + i, title: 'Single'+ (2 * i) });
-    // This month
-    multidayMixedPerfArray.push({ startDate: moment().format('YYYY-MM-') + i, endDate: moment().format('YYYY-MM-') + i, title: 'Single'+ ((2 * i) - 1) });
-    multidayMixedPerfArray.push({ startDate: moment().format('YYYY-MM-') + i, endDate: moment().format('YYYY-MM-') + i, title: 'Single'+ (2 * i) });
-    // Next month
-    multidayMixedPerfArray.push({ startDate: moment().add(1, 'month').format('YYYY-MM-') + i, endDate: moment().add(1, 'month').format('YYYY-MM-') + i, title: 'Single'+ ((2 * i) - 1) });
-    multidayMixedPerfArray.push({ startDate: moment().add(1, 'month').format('YYYY-MM-') + i, endDate: moment().add(1, 'month').format('YYYY-MM-') + i, title: 'Single'+ (2 * i) });
+    for (var j = 0; j < 10; j++) {
+      multidayMixedPerfArray.push({ startDate: moment().format('YYYY-MM-') + i, endDate: moment().format('YYYY-MM-') + i });
+    }
   }
 
   var start = moment();

--- a/example/test.js
+++ b/example/test.js
@@ -107,6 +107,39 @@ $( function() {
     }
   });
 
+  // test multi-day event performance
+  // ================================================================================
+  var multidayMixedPerfArray = [
+    { startDate: moment().format('YYYY-MM-') + '12', endDate: moment().format('YYYY-MM-') + '17', title: 'Multi1' },
+    { startDate: moment().format('YYYY-MM-') + '24', endDate: moment().format('YYYY-MM-') + '27', title: 'Multi2' },
+  ];
+
+  // Add two events a day for three months
+  for (var i = 1; i < 28; i++) {
+    // Last month
+    multidayMixedPerfArray.push({ startDate: moment().add(-1, 'month').format('YYYY-MM-') + i, endDate: moment().add(-1, 'month').format('YYYY-MM-') + i, title: 'Single'+ ((2 * i) - 1) });
+    multidayMixedPerfArray.push({ startDate: moment().add(-1, 'month').format('YYYY-MM-') + i, endDate: moment().add(-1, 'month').format('YYYY-MM-') + i, title: 'Single'+ (2 * i) });
+    // This month
+    multidayMixedPerfArray.push({ startDate: moment().format('YYYY-MM-') + i, endDate: moment().format('YYYY-MM-') + i, title: 'Single'+ ((2 * i) - 1) });
+    multidayMixedPerfArray.push({ startDate: moment().format('YYYY-MM-') + i, endDate: moment().format('YYYY-MM-') + i, title: 'Single'+ (2 * i) });
+    // Next month
+    multidayMixedPerfArray.push({ startDate: moment().add(1, 'month').format('YYYY-MM-') + i, endDate: moment().add(1, 'month').format('YYYY-MM-') + i, title: 'Single'+ ((2 * i) - 1) });
+    multidayMixedPerfArray.push({ startDate: moment().add(1, 'month').format('YYYY-MM-') + i, endDate: moment().add(1, 'month').format('YYYY-MM-') + i, title: 'Single'+ (2 * i) });
+  }
+
+  var start = moment();
+
+  clndr.multiday = $('#multiday-mixed-performance').clndr({
+    events: multidayMixedPerfArray,
+    multiDayEvents: {
+      startDate: 'startDate',
+      endDate: 'endDate',
+      singleDay: 'date'
+    }
+  });
+
+$('#multiday-mixed-performance-val').text(moment.duration(moment().diff(start)).asSeconds());
+
   // test really long multi-day events
   // ================================================================================
   var multidayLongArray = [

--- a/src/clndr.js
+++ b/src/clndr.js
@@ -375,20 +375,23 @@
     for(j; j < l; j++) {
       // keep in mind that the events here already passed the month/year test.
       // now all we have to compare is the moment.date(), which returns the day of the month.
-      if(self.options.multiDayEvents) {
-        var start = monthEvents[j]._clndrStartDateObject;
-        var end = monthEvents[j]._clndrEndDateObject;
-        // if today is the same day as start or is after the start, and
-        // if today is the same day as the end or before the end ...
-        // woohoo semantics!
-        if( ( day.isSame(start, 'day') || day.isAfter(start, 'day') ) &&
-          ( day.isSame(end, 'day') || day.isBefore(end, 'day') ) ) {
-          eventsToday.push( monthEvents[j] );
+      var e = monthEvents[j];
+      var start = e._clndrStartDateObject;
+      var end = e._clndrEndDateObject;
+
+      // Check if multiday events are enabled and if the current event is
+      // longer than a day
+      if (self.options.multiDayEvents && end.diff(start, 'day' > 0)) {
+        // Same rules as before to check if the event is on the current day.
+        // Could be replaced if moment.js dependancy upgraded to 2.9 with
+        // if (day.isSame(start, 'day') || day.isBetween(start,end) || day.isSame(end, 'day'))
+        if((day.isSame(start, 'day') || day.isAfter(start, 'day'))
+        && (day.isSame(end, 'day') || day.isBefore(end, 'day'))) {
+          eventsToday.push(e);
         }
-      } else {
-        if( monthEvents[j]._clndrDateObject.date() == day.date() ) {
-          eventsToday.push( monthEvents[j] );
-        }
+      }
+      else if (day.isSame(start, 'day')){
+        eventsToday.push(e);
       }
     }
 


### PR DESCRIPTION
This is a performance improvement I've implemented on a local version of clndr.js

The check to see if a multi day event is on the current day takes significantly longer than it's single day counterpart. As the number of events increase you get a visible lag on the initial load and when changing months. This change checks if the event is more than one day before doing the multiday check and falls back to the single day check if not.

I've added a test for this that has 2 multiday events and 280 single day events. Before this change it took about .7 seconds to render, after it's about .3 second. The savings stay around 50% as you increase/decrease the number of single day events.