### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "clndr",
-  "version": "1.2.10",
   "main": "clndr.min.js",
   "homepage": "http://kylestetz.github.io/CLNDR/",
   "keywords": ["clndr", "calendar", "clndrjs", "templating"],


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property