### PR TITLE
Fixed extra comma on creating properties of a day object

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -415,7 +415,7 @@
     var properties = {
       isInactive: false,
       isAdjacentMonth: false,
-      isToday: false,
+      isToday: false
     };
     var extraClasses = "";
 


### PR DESCRIPTION
IE11 breaks the CLNDR with this extra comma :)