### PR TITLE
Unbind events before making events

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -638,6 +638,15 @@
       eventType = 'touchstart';
     }
 
+    // Make sure we don't already have events
+    $container.off( eventType +'.clndr', '.'+this.options.targets.day )
+    .off( eventType +'.clndr', '.'+this.options.targets.empty )
+    .off( eventType +'.clndr', '.'+self.options.targets.previousButton )
+    .off( eventType +'.clndr', '.'+self.options.targets.nextButton )
+    .off( eventType +'.clndr', '.'+self.options.targets.todayButton )
+    .off( eventType +'.clndr', '.'+self.options.targets.nextYearButton )
+    .off( eventType +'.clndr', '.'+self.options.targets.previousYearButton );
+
     // target the day elements and give them click events
     $container.on(eventType +'.clndr', '.'+this.options.targets.day, function(event) {
       if(self.options.clickEvents.click) {

--- a/src/clndr.js
+++ b/src/clndr.js
@@ -640,12 +640,12 @@
 
     // Make sure we don't already have events
     $container.off( eventType +'.clndr', '.'+this.options.targets.day )
-    .off( eventType +'.clndr', '.'+this.options.targets.empty )
-    .off( eventType +'.clndr', '.'+self.options.targets.previousButton )
-    .off( eventType +'.clndr', '.'+self.options.targets.nextButton )
-    .off( eventType +'.clndr', '.'+self.options.targets.todayButton )
-    .off( eventType +'.clndr', '.'+self.options.targets.nextYearButton )
-    .off( eventType +'.clndr', '.'+self.options.targets.previousYearButton );
+      .off( eventType +'.clndr', '.'+this.options.targets.empty )
+      .off( eventType +'.clndr', '.'+this.options.targets.previousButton )
+      .off( eventType +'.clndr', '.'+this.options.targets.nextButton )
+      .off( eventType +'.clndr', '.'+this.options.targets.todayButton )
+      .off( eventType +'.clndr', '.'+this.options.targets.nextYearButton )
+      .off( eventType +'.clndr', '.'+this.options.targets.previousYearButton );
 
     // target the day elements and give them click events
     $container.on(eventType +'.clndr', '.'+this.options.targets.day, function(event) {


### PR DESCRIPTION
After a destroy the original events are still bound which means context isn't what it should be.

Unbind the events before they cause problems. Issue for this is #215