### PR TITLE
Fixed a bug with constraints in other months

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -230,7 +230,7 @@
 
         // If we've got constraints set, make sure the interval is within them.
         if (this.options.constraints) {
-            // First check if the start date exists & is later than now.
+            // First check if the startDate exists & is later than now.
             if (this.options.constraints.startDate) {
                 var startMoment = moment(this.options.constraints.startDate);
 
@@ -242,9 +242,17 @@
                     this.month
                         .set('month', startMoment.month())
                         .set('year', startMoment.year());
+
+                    // Check the intervalEnd is not earlier than now.
+                    if (this.intervalEnd.isBefore(startMoment, 'month')) {
+                        this.intervalEnd
+                            .set('month', startMoment.month())
+                            .set('year', startMoment.year());
+                    }
                 }
             }
-            // Make sure the intervalEnd is before the endDate
+
+            // Make sure the intervalEnd is before the endDate.
             if (this.options.constraints.endDate) {
                 var endMoment = moment(this.options.constraints.endDate);
 
@@ -255,6 +263,13 @@
                     this.month
                         .set('month', endMoment.month())
                         .set('year', endMoment.year());
+
+                    // Check the intervalStart is not later than now.
+                    if (this.intervalStart.isAfter(endMoment, 'month')) {
+                        this.intervalStart
+                            .set('month', endMoment.month())
+                            .set('year', endMoment.year());
+                    }
                 }
             }
         }
@@ -1349,7 +1364,7 @@
                 .subtract(1, 'days')
                 .endOf('month');
         }
-        
+
         // No need to re-render if we didn't change months.
         if (!ctx.intervalStart.isSame(orig.start)
             || !ctx.intervalEnd.isSame(orig.end))

--- a/tests/test.html
+++ b/tests/test.html
@@ -75,19 +75,37 @@
 
         <p>
             <strong>clndr.constraints</strong> Test start and end constraints.
-            (4th of this month to the 12th of next month). Logs in the console.
+            (the 4th of this month to the 12th of next month). Logs in the console.
         </p>
         <div id="constraints" class="cal1"></div>
 
         <p>
+            <strong>clndr.prevNextMonthConstriants</strong> Test start and end constraints.
+            (the 22nd of previous month to the 5th of next month).
+        </p>
+        <div id="prev-next-month-constraints" class="cal1"></div>
+
+        <p>
+            <strong>clndr.prevMonthConstriants</strong> Test start and end constraints.
+            (the 2nd to the 5th of previous month).
+        </p>
+        <div id="prev-month-constraints" class="cal1"></div>
+
+        <p>
+            <strong>clndr.nextMonthConstriants</strong> Test start and end constraints.
+            (the 22nd to the 25th of next month).
+        </p>
+        <div id="next-month-constraints" class="cal1"></div>
+
+        <p>
             <strong>clndr.startConstraint</strong> Test start constraint. (4th
-            of this month). Logs in the console.
+            of this month).
         </p>
         <div id="start-constraint" class="cal1"></div>
 
         <p>
             <strong>clndr.endConstraint</strong> Test end constraint. (12th of
-            next month). Logs in the console.
+            next month).
         </p>
         <div id="end-constraint" class="cal1"></div>
 
@@ -148,6 +166,18 @@
             of the next month.
         </p>
         <div id="one-week-with-constraints" class="cal2"></div>
+
+        <p>
+            <strong>clndr.twoWeeksWithPrevMonthConstriants</strong> Test start and end constraints.
+            (the 2nd to the 5th of previous month).
+        </p>
+        <div id="one-week-with-prev-month-constraints" class="cal2"></div>
+
+        <p>
+            <strong>clndr.twoWeeksWithNextMonthConstriants</strong> Test start and end constraints.
+            (the 22nd to the 25th of next month).
+        </p>
+        <div id="one-week-with-next-month-constraints" class="cal2"></div>
 
         <p>
             <strong>clndr.selectedDate</strong> Should highlight the last date

--- a/tests/test.js
+++ b/tests/test.js
@@ -243,9 +243,39 @@ $( function() {
         }
     });
 
+    // Test constraints
+    // The 22nd of previous month to the 5th of next month
+    // =========================================================================
+    clndr.prevNextMonthConstriants = $('#prev-next-month-constraints').clndr({
+        constraints: {
+            startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '22',
+            endDate: moment().add(1, 'months').format('YYYY-MM-05')
+        },
+    });
+
+    // Test constraints
+    // The 2nd to the 5th of previous month
+    // =========================================================================
+    clndr.prevMonthConstraints = $('#prev-month-constraints').clndr({
+        constraints: {
+            startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '02',
+            endDate: moment().subtract(1, 'months').format('YYYY-MM-05')
+        },
+    });
+
+    // Test constraints
+    // The 22nd to the 25th of next month
+    // =========================================================================
+    clndr.nextMonthConstraints = $('#next-month-constraints').clndr({
+        constraints: {
+            startDate: moment().add(1, 'months').format('YYYY-MM-') + '22',
+            endDate: moment().add(1, 'months').format('YYYY-MM-25')
+        },
+    });
+
     // Test the start constraint by itself (4th of this month)
     // =========================================================================
-    clndr.startConstriant = $('#start-constraint').clndr({
+    clndr.startConstraint = $('#start-constraint').clndr({
         constraints: {
             startDate: moment().format('YYYY-MM-') + '04'
         }
@@ -253,7 +283,7 @@ $( function() {
 
     // Test the end constraint by itself (12th of next month)
     // =========================================================================
-    clndr.endConstriant = $('#end-constraint').clndr({
+    clndr.endConstraint = $('#end-constraint').clndr({
         constraints: {
             endDate: moment().add(1, 'months').format('YYYY-MM-') + '12'
         }
@@ -416,6 +446,38 @@ $( function() {
         constraints: {
             startDate: moment().format('YYYY-MM-') + '04',
             endDate: moment().add(1, 'months').format('YYYY-MM-12')
+        }
+    });
+
+    // Test lengthOfTime.days option with constraints (14 days incremented by 7)
+    // The 2nd to the 5th of previous month
+    // =========================================================================
+    clndr.twoWeeksWithPrevMonthConstraints = $('#one-week-with-prev-month-constraints').clndr({
+        template: $('#clndr-oneweek-template').html(),
+        lengthOfTime: {
+            days: 14,
+            interval: 7,
+            startDate: moment().weekday(0)
+        },
+        constraints: {
+            startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '02',
+            endDate: moment().subtract(1, 'months').format('YYYY-MM-05')
+        }
+    });
+
+    // Test lengthOfTime.days option with constraints (14 days incremented by 7)
+    // The 22nd to the 25th of next month
+    // =========================================================================
+    clndr.twoWeeksWithNextMonthConstraints = $('#one-week-with-next-month-constraints').clndr({
+        template: $('#clndr-oneweek-template').html(),
+        lengthOfTime: {
+            days: 14,
+            interval: 7,
+            startDate: moment().weekday(0)
+        },
+        constraints: {
+            startDate: moment().add(1, 'months').format('YYYY-MM-') + '22',
+            endDate: moment().add(1, 'months').format('YYYY-MM-25')
         }
     });
 


### PR DESCRIPTION
The back and next buttons are not blocked on initial render if the constraints are fully in the previous or next month (because the `intervalStart` and `intervalEnd` are incorrect).
Tests are included.