### PR TITLE
Constraint fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ $('.parent-element').clndr({
         days: null,
 
         // This is the amount of months or days that will move forward/back when
-        // paging the calendar. With days=17 and interval=7, you would have a
+        // paging the calendar. With days=14 and interval=7, you would have a
         // 2-week calendar that pages forward and backward 1 week at a time.
         interval: 1
     },

--- a/src/clndr.js
+++ b/src/clndr.js
@@ -211,7 +211,7 @@
                 if (this.options.lengthOfTime.startDate) {
                     this.intervalStart =
                         moment(this.options.lengthOfTime.startDate)
-                            .startOf('week');
+                            .startOf('day');
                 } else {
                     this.intervalStart = moment().weekday(0).startOf('day');
                 }

--- a/tests/test.html
+++ b/tests/test.html
@@ -80,19 +80,19 @@
         <div id="constraints" class="cal1"></div>
 
         <p>
-            <strong>clndr.prevNextMonthConstriants</strong> Test start and end constraints.
+            <strong>clndr.prevNextMonthConstraints</strong> Test start and end constraints.
             (the 22nd of previous month to the 5th of next month).
         </p>
         <div id="prev-next-month-constraints" class="cal1"></div>
 
         <p>
-            <strong>clndr.prevMonthConstriants</strong> Test start and end constraints.
+            <strong>clndr.prevMonthConstraints</strong> Test start and end constraints.
             (the 2nd to the 5th of previous month).
         </p>
         <div id="prev-month-constraints" class="cal1"></div>
 
         <p>
-            <strong>clndr.nextMonthConstriants</strong> Test start and end constraints.
+            <strong>clndr.nextMonthConstraints</strong> Test start and end constraints.
             (the 22nd to the 25th of next month).
         </p>
         <div id="next-month-constraints" class="cal1"></div>
@@ -168,13 +168,13 @@
         <div id="one-week-with-constraints" class="cal2"></div>
 
         <p>
-            <strong>clndr.twoWeeksWithPrevMonthConstriants</strong> Test start and end constraints.
+            <strong>clndr.twoWeeksWithPrevMonthConstraints</strong> Test start and end constraints.
             (the 2nd to the 5th of previous month).
         </p>
         <div id="one-week-with-prev-month-constraints" class="cal2"></div>
 
         <p>
-            <strong>clndr.twoWeeksWithNextMonthConstriants</strong> Test start and end constraints.
+            <strong>clndr.twoWeeksWithNextMonthConstraints</strong> Test start and end constraints.
             (the 22nd to the 25th of next month).
         </p>
         <div id="one-week-with-next-month-constraints" class="cal2"></div>

--- a/tests/test.js
+++ b/tests/test.js
@@ -246,7 +246,7 @@ $( function() {
     // Test constraints
     // The 22nd of previous month to the 5th of next month
     // =========================================================================
-    clndr.prevNextMonthConstriants = $('#prev-next-month-constraints').clndr({
+    clndr.prevNextMonthConstraints = $('#prev-next-month-constraints').clndr({
         constraints: {
             endDate: moment().add(1, 'months').format('YYYY-MM-05'),
             startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '22'

--- a/tests/test.js
+++ b/tests/test.js
@@ -156,7 +156,7 @@ $( function() {
             title: 'Multi2',
             endDate: moment().format('YYYY-MM-') + '27',
             startDate: moment().format('YYYY-MM-') + '24'
-        },
+        }
     ];
 
     // Add ten events every day this month that are only a day long,
@@ -248,9 +248,9 @@ $( function() {
     // =========================================================================
     clndr.prevNextMonthConstriants = $('#prev-next-month-constraints').clndr({
         constraints: {
-            startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '22',
-            endDate: moment().add(1, 'months').format('YYYY-MM-05')
-        },
+            endDate: moment().add(1, 'months').format('YYYY-MM-05'),
+            startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '22'
+        }
     });
 
     // Test constraints
@@ -258,9 +258,9 @@ $( function() {
     // =========================================================================
     clndr.prevMonthConstraints = $('#prev-month-constraints').clndr({
         constraints: {
-            startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '02',
-            endDate: moment().subtract(1, 'months').format('YYYY-MM-05')
-        },
+            endDate: moment().subtract(1, 'months').format('YYYY-MM-05'),
+            startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '02'
+        }
     });
 
     // Test constraints
@@ -268,9 +268,9 @@ $( function() {
     // =========================================================================
     clndr.nextMonthConstraints = $('#next-month-constraints').clndr({
         constraints: {
-            startDate: moment().add(1, 'months').format('YYYY-MM-') + '22',
-            endDate: moment().add(1, 'months').format('YYYY-MM-25')
-        },
+            endDate: moment().add(1, 'months').format('YYYY-MM-25'),
+            startDate: moment().add(1, 'months').format('YYYY-MM-') + '22'
+        }
     });
 
     // Test the start constraint by itself (4th of this month)
@@ -444,7 +444,7 @@ $( function() {
             startDate: moment().weekday(0)
         },
         constraints: {
-            startDate: moment().format('YYYY-MM-') + '04',
+            startDate: moment().format('YYYY-MM-04'),
             endDate: moment().add(1, 'months').format('YYYY-MM-12')
         }
     });
@@ -460,8 +460,8 @@ $( function() {
             startDate: moment().weekday(0)
         },
         constraints: {
-            startDate: moment().subtract(1, 'months').format('YYYY-MM-') + '02',
-            endDate: moment().subtract(1, 'months').format('YYYY-MM-05')
+            endDate: moment().subtract(1, 'months').format('YYYY-MM-05'),
+            startDate: moment().subtract(1, 'months').format('YYYY-MM-02')
         }
     });
 
@@ -476,16 +476,16 @@ $( function() {
             startDate: moment().weekday(0)
         },
         constraints: {
-            startDate: moment().add(1, 'months').format('YYYY-MM-') + '22',
-            endDate: moment().add(1, 'months').format('YYYY-MM-25')
+            endDate: moment().add(1, 'months').format('YYYY-MM-25'),
+            startDate: moment().add(1, 'months').format('YYYY-MM-22')
         }
     });
 
     // Test selectedDate option
     // =========================================================================
     clndr.selectedDate = $('#selected-date').clndr({
-        template: $('#clndr-template').html(),
-        trackSelectedDate: true
+        trackSelectedDate: true,
+        template: $('#clndr-template').html()
     });
 
     // Test selectedDate option with ignoreInactiveDaysInSelection
@@ -496,7 +496,7 @@ $( function() {
         ignoreInactiveDaysInSelection: true,
         constraints: {
             endDate: moment().add(1, 'months').format('YYYY-MM-12'),
-            startDate: moment().subtract(1, 'months').format('YYYY-MM-DD'),
+            startDate: moment().subtract(1, 'months').format('YYYY-MM-DD')
         }
     });
 });


### PR DESCRIPTION
This update handles the constraint corner-cases that @dimko prepared in the test file. The additional logic from PR #253 handles monthly calendars but didn't address the oddities for weekly calendars. For example, some weekly calendars would render without any days/weeks because the constraints conflicted with the interval.

This PR addresses all cases for monthly and weekly calendars and all tests should now pass. I'd invite a second pair of eyes and I know the constraint logic in lines 239 to 320 is somewhat confusing. It should be commented enough to give some clarity though :stuck_out_tongue: 