### PR TITLE
Fix dates of the previous month with momentjs 2.17.0+

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -492,12 +492,12 @@
             }
 
             if (this.options.showAdjacentMonths) {
-                for (var i = 0; i < diff; i++) {
+                for (var i = 1; i <= diff; i++) {
                     var day = moment([
                         startDate.year(),
                         startDate.month(),
-                        i - diff + 1
-                    ]);
+                        i
+                    ]).subtract(diff, 'days');
                     daysArray.push(
                         this.createDayObject(
                             day,

--- a/tests/test.html
+++ b/tests/test.html
@@ -264,7 +264,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.0/moment.min.js"></script>
     <script src="../src/clndr.js"></script>
     <script src="test.js"></script>
 </body>


### PR DESCRIPTION
refs #288 

I replace the use of negative date by the moment `subtract` function.
And I update the test file to use moment 2.17.0.