### PR TITLE
[Issue#301] for..in loop is crashing on months object array

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -746,7 +746,7 @@
             }
 
             // Get the total number of rows across all months
-            for (i in months) {
+            for (i = 0; i < months.length; i++) {
                 numberOfRows += Math.ceil(months[i].days.length / 7);
             }
 


### PR DESCRIPTION
Bug:
      https://github.com/kylestetz/CLNDR/issues/301

Changes:
	- Replace for..in loop with a simple for loop