### PR TITLE
[Issue#330] bug: removal of `inactive` css when `options.targes.day !== "day"`

### DIFF
--- a/src/clndr.js
+++ b/src/clndr.js
@@ -808,7 +808,8 @@
             // In the interest of clarity we're just going to remove all
             // inactive classes and re-apply them each render.
             for (var target in this.options.targets) {
-                if (target != this.options.targets.day) {
+                // ignore the day items
+                if (target !== 'day') {
                     this.element.find('.' + this.options.targets[target])
                         .toggleClass(
                             this.options.classes.inactive,


### PR DESCRIPTION


fix: instead of comparing the key name (iterated item) with the value of `this.options.targets.day`, compare with its key name (simply `'day'`)